### PR TITLE
feat: generate endor compatible socket code

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,4 @@
 a.out.js
 a.out.wasm
+a.out.debug.js
+a.out.debug.wasm

--- a/examples/tcp-client-example/Makefile
+++ b/examples/tcp-client-example/Makefile
@@ -1,8 +1,15 @@
+all: a.out.js a.out.debug.js
+
 # Phony because we are working with the compiler generated code
 .PHONY: a.out.js
 a.out.js: main.c
-	../../emcc $< -o $@
+	../../emcc -O3 -sASYNCIFY $< -o $@
+
+# Phony because we are working with the compiler generated code
+.PHONY: a.out.debug.js
+a.out.debug.js: main.c
+	../../emcc -g -sASYNCIFY -sSOCKET_DEBUG -sSYSCALL_DEBUG $< -o $@
 
 .PHONY: clean
 clean:
-	rm a.out.js a.out.wasm
+	rm -f a.out.{,debug}.js a.out.{,debug}wasm

--- a/examples/tcp-client-example/Makefile
+++ b/examples/tcp-client-example/Makefile
@@ -1,3 +1,5 @@
+# Phony because we are working with the compiler generated code
+.PHONY: a.out.js
 a.out.js: main.c
 	../../emcc $< -o $@
 

--- a/examples/tcp-client-example/main.c
+++ b/examples/tcp-client-example/main.c
@@ -2,6 +2,7 @@
  * Originally taken from https://stackoverflow.com/questions/22077802/simple-c-example-of-doing-an-http-post-and-consuming-the-response
  */
 
+#include <errno.h>
 #include <stdio.h> /* printf, sprintf */
 #include <stdlib.h> /* exit */
 #include <unistd.h> /* read, write, close */
@@ -9,50 +10,51 @@
 #include <sys/socket.h> /* socket, connect */
 #include <netinet/in.h> /* struct sockaddr_in, struct sockaddr */
 #include <netdb.h> /* struct hostent, gethostbyname */
+#include <arpa/inet.h> /* inet_addr */
 
-void error(const char *msg) { perror(msg); exit(0); }
+#include <emscripten.h>
+
+void error(const char *msg) { perror(msg); exit(1); }
 
 int main(int argc,char *argv[])
 {
     /* first what are we going to send and where are we going to send it? */
-    int portno =        80;
-    char *host =        "api.somesite.com";
-    char *message_fmt = "POST /apikey=%s&command=%s HTTP/1.0\r\n\r\n";
+    int portno = 80;
+    char *host = "192.168.10.20";
+    char *message = "GET / HTTP/1.0\r\n\r\n";
 
     struct hostent *server;
     struct sockaddr_in serv_addr;
     int sockfd, bytes, sent, received, total;
-    char message[1024],response[4096];
-
-    if (argc < 3) { puts("Parameters: <apikey> <command>"); exit(0); }
-
-    /* fill in the parameters */
-    sprintf(message,message_fmt,argv[1],argv[2]);
-    printf("Request:\n%s\n",message);
+    char response[4096];
 
     /* create the socket */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0) error("ERROR opening socket");
 
-    /* lookup the ip address */
-    server = gethostbyname(host);
-    if (server == NULL) error("ERROR no such host");
+    printf("sockfd is: %d\n", sockfd);
 
     /* fill in the structure */
-    memset(&serv_addr,0,sizeof(serv_addr));
+    memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family = AF_INET;
     serv_addr.sin_port = htons(portno);
-    memcpy(&serv_addr.sin_addr.s_addr,server->h_addr,server->h_length);
+    serv_addr.sin_addr.s_addr = inet_addr(host);
+
+    printf("about to connect\n");
 
     /* connect the socket */
-    if (connect(sockfd,(struct sockaddr *)&serv_addr,sizeof(serv_addr)) < 0)
+    if (connect(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0)
         error("ERROR connecting");
+
+    printf("connected\n");
 
     /* send the request */
     total = strlen(message);
     sent = 0;
+    printf("writing %s (%lu characters)\n", message, strlen(message));
     do {
-        bytes = write(sockfd,message+sent,total-sent);
+        bytes = write(sockfd, message + sent, total - sent);
+        printf("written %d bytes to socket\n", bytes);
         if (bytes < 0)
             error("ERROR writing message to socket");
         if (bytes == 0)
@@ -61,16 +63,23 @@ int main(int argc,char *argv[])
     } while (sent < total);
 
     /* receive the response */
-    memset(response,0,sizeof(response));
-    total = sizeof(response)-1;
+    memset(response, 0, sizeof(response));
+    total = sizeof(response) - 1;
     received = 0;
     do {
-        bytes = read(sockfd,response+received,total-received);
-        if (bytes < 0)
-            error("ERROR reading response from socket");
-        if (bytes == 0)
-            break;
-        received+=bytes;
+      errno = 0;
+      bytes = read(sockfd, response + received, total - received);
+      if (errno == EAGAIN) {
+        printf("EAGAIN\n");
+        emscripten_sleep(1000);
+        continue;
+      }
+      printf("read %d bytes\n", bytes);
+      if (bytes < 0)
+        error("ERROR reading response from socket");
+      if (bytes == 0)
+        break;
+      received += bytes;
     } while (received < total);
 
     /*

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1732749044,
+        "narHash": "sha256-T38FQOg0BV5M8FN1712fovzNakSOENEYs+CSkg31C9Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "0c5b4ecbed5b155b705336aa96d878e55acd8685",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1727802920,
-        "narHash": "sha256-HP89HZOT0ReIbI7IJZJQoJgxvB2Tn28V6XS3MNKnfLs=",
+        "lastModified": 1732393136,
+        "narHash": "sha256-5SBCirk5V+X4eSwvMdYX3s1ARhKBbfzdyt+RYAZcsvQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "27e30d177e57d912d614c88c622dcfdb2e6e6515",
+        "rev": "a51f60e0dd3bcff610dd7d308b29db95a2ce45ae",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "27e30d17",
+        "ref": "pull/343743/head",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,26 +3,26 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
-    # Nix unstable version pinned to this commit.
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/27e30d17";
+    # Use nixpkgs pinned to https://github.com/NixOS/nixpkgs/pull/343743 so that -O3 works as expected
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/pull/343743/head";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system: 
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
-        
+
         pkgs-unstable = import nixpkgs-unstable {
           inherit system;
         };
       in
       {
         devShells.default = pkgs.mkShell {
-          packages = [ 
-            pkgs.nodejs_20 
+          packages = [
+            pkgs.nodejs_20
             pkgs.jq
             pkgs.nodePackages.typescript
             pkgs.python312
@@ -36,7 +36,7 @@
             # This is not ideal, but the emscripten package applies certain patches to
             # ensure clang finds the libraries and required files.
             cp -f ${pkgs-unstable.emscripten}/share/emscripten/emcc.py ./
-          
+
             export EM_CONFIG=${pkgs-unstable.emscripten}/share/emscripten/.emscripten
           '';
         };

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -315,9 +315,9 @@ var SyscallsLibrary = {
 // When building with WASMFS the socket syscalls are implemented natively in
 // libwasmfs.a.
 #if PROXY_POSIX_SOCKETS == 0 && WASMFS == 0
-  $getSocketFromFD__deps: ['$SOCKFS', '$FS'],
+  $getSocketFromFD__deps: ['$ENDOR_SOCKFS', '$FS'],
   $getSocketFromFD: (fd) => {
-    var socket = SOCKFS.getSocket(fd);
+    var socket = ENDOR_SOCKFS.getSocket(fd);
     if (!socket) throw new FS.ErrnoError({{{ cDefs.EBADF }}});
 #if SYSCALL_DEBUG
     dbg(`    (socket: "${socket.path}")`);
@@ -337,9 +337,9 @@ var SyscallsLibrary = {
 #endif
     return info;
   },
-  __syscall_socket__deps: ['$SOCKFS'],
+  __syscall_socket__deps: ['$ENDOR_SOCKFS'],
   __syscall_socket: (domain, type, protocol) => {
-    var sock = SOCKFS.createSocket(domain, type, protocol);
+    var sock = ENDOR_SOCKFS.createSocket(domain, type, protocol);
 #if ASSERTIONS
     assert(sock.stream.fd < 64); // XXX ? select() assumes socket fd values are in 0..63
 #endif


### PR DESCRIPTION
A very primitive implementation. The example worker that was compiled with this modified code is at https://github.com/endorhq/endor/pull/86.

It has very basic socket primitives that use the endor networking support to reach internal services.